### PR TITLE
feat: validate throttle priority

### DIFF
--- a/adaptive_test.go
+++ b/adaptive_test.go
@@ -16,6 +16,27 @@ import (
 	"golang.org/x/time/rate"
 )
 
+func TestAdaptiveThrottlePriority(t *testing.T) {
+	throttle := NewAdaptiveThrottle(0)
+
+	testErr := fmt.Errorf("test")
+	throttleFn := func(ctx context.Context) (int, error) {
+		return 1, RejectedError(testErr)
+	}
+
+	priority := Low
+	_, err := Throttle(context.Background(), throttle, priority, throttleFn)
+	if err != nil && !errors.Is(err, testErr) {
+		t.Fatal(err)
+	}
+
+	ctx := WithPriority(context.Background(), 4)
+	_, err = Throttle(ctx, throttle, 0, throttleFn)
+	if err != nil && !errors.Is(err, testErr) {
+		t.Fatal(err)
+	}
+}
+
 func TestAdaptiveThrottleBasic(t *testing.T) {
 	duration := 28 * time.Second
 	start := time.Now()


### PR DESCRIPTION
This PR addresses panics which can occur in two places:
1. When the number of priorities to track is set to 0 when constructing a throttle
2. When trying to call `Throttle` with a priority higher than the number of priorities tracked by the adaptive throttle

The approach taken here is to ensure at least 1 priority is tracked when constructing the throttle and that the priority used in the `Throttle` function is within the range supported by the adaptive throttle. Alternatively, an error could be returned in both of these cases, but that would change the usage pattern of the library.
