### PR TITLE
feat: validate priority range

### DIFF
--- a/priority.go
+++ b/priority.go
@@ -1,5 +1,9 @@
 package bulwark
 
+import (
+	"fmt"
+)
+
 // StandardPriorities is the number of priority levels that are available.
 // This value should be used when creating a new AdaptiveThrottle when the
 // default Priority constants are used.
@@ -9,26 +13,107 @@ package bulwark
 //		if err != nil {
 //			// handle the error
 //	 }
-const StandardPriorities = 4
+var StandardPriorities = NewPriorityRange(Low)
 
 // Priority determines the importance of a request in ascending order.
 // e.g. priority 0 is more important than priority 1.
 //
 // When a system reaches its capacity, it will sort requests by their priority
 // and process them. Lower-priority requests can either be delayed or dropped.
-type Priority int8
+type Priority struct {
+	p int
+}
+
+func (p Priority) Value() int {
+	return p.p
+}
 
 // These are pre-defined priority levels that can be used, but any int value
 // can be used as a priority.
-const (
+var (
 	// Use High when for requests that are critical to the overall experience.
-	High Priority = 0
+	High Priority = Priority{0}
 	// Use Important for requests that are important, but not critical.
-	Important Priority = 1
+	Important Priority = Priority{1}
 	// Use Medium for noncritical requests where an elevated latency or
 	// failure rate would not significantly impact the experience.
-	Medium Priority = 2
+	Medium Priority = Priority{2}
 	// Use Low for trivial requests and good for any system that can retry
 	// later when the system has spare capacity.
-	Low Priority = 3
+	Low Priority = Priority{3}
 )
+
+var allPriorities = []Priority{Low, Medium, Important, High}
+
+// MustPriorityFromValue returns a Priority from an int value. If the value is
+// not found, it will panic.
+func MustPriorityFromValue(p int) Priority {
+	for _, priority := range allPriorities {
+		if priority.Value() == p {
+			return priority
+		}
+	}
+
+	panic(fmt.Sprintf("bulwark: priority not found: %d", p))
+}
+
+// AdaptPriorityFromValue returns a Priority from an int value. If the value is
+// not found, it will return the lowest priority.
+func AdaptPriorityFromValue(p int) Priority {
+	for _, priority := range allPriorities {
+		if priority.Value() == p {
+			return priority
+		}
+	}
+
+	return Low
+}
+
+// PriorityRange is a range of priorities.
+type PriorityRange struct {
+	lowest, highest Priority
+	validate        ValidatorFunc
+}
+
+// PriorityRangeOption is an option for a PriorityRange.
+type PriorityRangeOption func(r *PriorityRange)
+
+// WithRangeValidator sets the validator for the priority range.
+func WithRangeValidator(v ValidatorFunc) PriorityRangeOption {
+	return func(r *PriorityRange) {
+		r.validate = v
+	}
+}
+
+// NewPriorityRange creates a PriorityRange which represents the range
+// [provided lowest, High].
+func NewPriorityRange(lowest Priority, options ...PriorityRangeOption) PriorityRange {
+	r := PriorityRange{
+		lowest:   lowest,
+		highest:  High,
+		validate: OnInvalidPriorityAdjust,
+	}
+
+	for _, option := range options {
+		option(&r)
+	}
+
+	return r
+}
+
+// Range returns the number of priorities in the range.
+func (r PriorityRange) Range() int {
+	// the lower the priority, the higher the value.
+	return (r.lowest.Value() - r.highest.Value()) + 1
+}
+
+// Lowest returns the lowest priority in the range.
+func (r PriorityRange) Lowest() Priority {
+	return r.lowest
+}
+
+// Validate validates a priority. If the priority is not valid, it will return
+// the lowest priority.
+func (r PriorityRange) Validate(p Priority) (Priority, error) {
+	return r.validate(p, r)
+}

--- a/validator.go
+++ b/validator.go
@@ -7,13 +7,18 @@ import (
 	"github.com/deixis/faults"
 )
 
+// ValidatorFunc should return the validated priority value. If the priority is
+// invalid, the function should return an error.
+type ValidatorFunc func(p Priority, priorities PriorityRange) (Priority, error)
+
 var (
 	// OnInvalidPriorityPanic panics when a priority is out of range.
 	// A priority is out of range when it is less than 0 or greater than or equal
 	// to priorities-1.
-	OnInvalidPriorityPanic = func(p Priority, priorities int) (Priority, error) {
-		if p < 0 || int(p) >= priorities-1 {
-			panic(fmt.Sprintf("bulwark: priority must be in the range [0, %d), but got %d", priorities, p))
+	OnInvalidPriorityPanic = func(p Priority, priorities PriorityRange) (Priority, error) {
+		if p.Value() >= priorities.Lowest().Value() {
+			panic(fmt.Sprintf("bulwark: priority must be in the range [0, %d), but got %d",
+				priorities.Lowest().Value(), p.Value()))
 		}
 
 		return p, nil
@@ -23,25 +28,26 @@ var (
 	// A negative priority will be set to the lowest priority.
 	// A priority is out of range when it is less than 0 or greater than or equal
 	// to priorities-1.
-	OnInvalidPriorityAdjust = func(p Priority, priorities int) (Priority, error) {
-		if p >= 0 && int(p) < priorities {
+	OnInvalidPriorityAdjust = func(p Priority, priorities PriorityRange) (Priority, error) {
+		if p.Value() <= priorities.Lowest().Value() {
 			return p, nil
 		}
-		slog.Warn("bulwark: priority is out of range", "max", priorities-1, "priority", p)
+		slog.Warn("bulwark: priority is out of range", "max", priorities.Lowest(), "priority", p)
 
 		// Receiving an invalid value is likely due to an input that was not properly
 		// validated, so this prevents abuse of the system.
-		return Priority(priorities - 1), nil
+		return priorities.Lowest(), nil
 	}
 
 	// OnInvalidPriorityError returns an error when a priority is out of range.
 	// A priority is out of range when it is less than 0 or greater than or equal
 	// to priorities-1.
-	OnInvalidPriorityError = func(p Priority, priorities int) (Priority, error) {
-		if p < 0 || int(p) >= priorities-1 {
+	OnInvalidPriorityError = func(p Priority, priorities PriorityRange) (Priority, error) {
+		if p.Value() > priorities.Lowest().Value() {
 			return p, faults.Bad(&faults.FieldViolation{
-				Field:       "priority",
-				Description: fmt.Sprintf("priority must be in the range [0, %d), but got %d", priorities, p),
+				Field: "priority",
+				Description: fmt.Sprintf("priority must be in the range [0, %d), but got %d",
+					priorities.Lowest().Value(), p.Value()),
 			})
 		}
 


### PR DESCRIPTION
There are two reasons that panics can arise with the current implementation:
1. We do not limit the value of the Priority. It’s just an integer, so the user could specify any value at all making it possible to call `Throttle` with a priority integer value greater than the number of priorities being managed.
2. We allow the user to specify how many priorities to manage, but we do not limit this value.

This PR seeks to address both of these issues. The first issue is addressed by limiting the possible priorities to only those defined in the library itself. The second issue is addressed by standardizing how an acceptable range of priorities is constructed. By making this range explicit, it is also easier to specify how to validate incoming priorities against that range.

These changes do require changing the function signature of the throttle constructor, but there are no cases at Infura where we construct a throttle without using the default StandardPriorities. That said, this library is new enough that I think it's important to constrain the problem so we do not encounter edge cases in the future.