### PR TITLE
fix: remove dead code and fix handling consistency

### DIFF
--- a/adaptive.go
+++ b/adaptive.go
@@ -204,11 +204,10 @@ type AdaptiveThrottleOption struct {
 }
 
 type adaptiveThrottleOptions struct {
-	k               float64
-	minRate         float64
-	d               time.Duration
-	isErrorAccepted func(err error) bool
-	validate        func(p Priority, priorities int) (Priority, error)
+	k        float64
+	minRate  float64
+	d        time.Duration
+	validate func(p Priority, priorities int) (Priority, error)
 }
 
 // WithAdaptiveThrottleRatio sets the ratio of the measured success rate and the rate that the throttle
@@ -241,15 +240,10 @@ func WithAdaptiveThrottleWindow(d time.Duration) AdaptiveThrottleOption {
 	}}
 }
 
-// Deprecated: Wrap errors with RejectedError instead and use the global DefaultRejectedErrors.
-//
-// WithAcceptedErrors sets the function that determines whether an error should
-// be considered for the throttling. When the call to fn returns true, the error
-// is not counted towards the throttling.
+// Deprecated: Wrap errors with RejectedError instead, or override the global IsRejectedError.
+// This option has no effect and will be removed in a future version.
 func WithAcceptedErrors(fn func(err error) bool) AdaptiveThrottleOption {
-	return AdaptiveThrottleOption{func(opts *adaptiveThrottleOptions) {
-		opts.isErrorAccepted = fn
-	}}
+	return AdaptiveThrottleOption{func(opts *adaptiveThrottleOptions) {}}
 }
 
 // WithPriorityValidator sets the function that validates input priority values.
@@ -368,10 +362,10 @@ func WithAdaptiveThrottle[T any](
 	case err == nil:
 		at.accept(priority, now)
 	case errors.Is(err, errRejected{}):
-		at.reject(priority, now)
-
 		// Unwrap error to return the original error to the caller
 		err = err.(errRejected).inner
+
+		fallthrough
 	case IsRejectedError(err):
 		at.reject(priority, now)
 	default:
@@ -419,7 +413,7 @@ type (
 )
 
 var (
-	// Deprecated: Override `IsRejectedError` instead and/or wrap errors with `RejectedError`.
+	// Deprecated: Override IsRejectedError instead and/or wrap errors with RejectedError.
 	//
 	// DefaultAcceptedErrors is the default function used to determine whether
 	// an error should be considered for the throttling.


### PR DESCRIPTION
## Summary

  - **Dead code removed**: `adaptiveThrottleOptions.isErrorAccepted` was
    set by `WithAcceptedErrors` but never transferred to the struct or
    consulted anywhere. Callers using this deprecated option got silently
    no-op behaviour. The field is removed; `WithAcceptedErrors` is now an
    explicit no-op with an updated deprecation notice.

  - **Consistent `errRejected` handling**: `WithAdaptiveThrottle` was
    rejecting before unwrapping the error, while `Throttle` and
    `Throttle[T]` unwrap first and then fall through to the reject step.
    `WithAdaptiveThrottle` now uses the same pattern. No behaviour change.

  - **Doc typo fix**: `DefaultRejectedErrors` (non-existent) corrected to
    `IsRejectedError` in the `DefaultAcceptedErrors` deprecation comment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mainly removes unused/dead option plumbing and makes `errRejected` handling consistent; throttling behavior should remain unchanged except for clearer deprecation/no-op behavior.
> 
> **Overview**
> Removes dead configuration around `AdaptiveThrottleOption` by dropping the unused `isErrorAccepted` field and making the deprecated `WithAcceptedErrors` an explicit no-op with updated deprecation guidance.
> 
> Aligns `WithAdaptiveThrottle`’s error classification with `Throttle`/`Throttle[T]` by unwrapping `errRejected` and then falling through to the standard `IsRejectedError` rejection path, and fixes a deprecation comment typo to reference `IsRejectedError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32160c423e56e89245a5f6a2eeed14f08e785d27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->